### PR TITLE
Initialize SwiftUI shell with website configuration and build workflow

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,21 @@
+name: iOS Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: |
+          xcodebuild -project Websmith.xcodeproj -scheme Websmith -configuration Release -sdk iphoneos -archivePath build/Websmith.xcarchive CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO archive
+          xcodebuild -exportArchive -archivePath build/Websmith.xcarchive -exportOptionsPlist ExportOptions.plist -exportPath build
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: Websmith
+          path: build/Websmith.ipa

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+/.build
+build
+*.xcarchive
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>development</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>compileBitcode</key>
+    <false/>
+    <key>stripSwiftSymbols</key>
+    <true/>
+</dict>
+</plist>

--- a/Websmith.xcodeproj/project.pbxproj
+++ b/Websmith.xcodeproj/project.pbxproj
@@ -1,0 +1,328 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		55521E67FB9D99D28BBCF691 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EB8C5CD97ED357D0B4AAF53 /* Foundation.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		11A411F19803F8D8AF7D2BCD /* WebsmithApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebsmithApp.swift; path = WebsmithApp/WebsmithApp.swift; sourceTree = "<group>"; };
+		404EB8F536823F8D56B14159 /* EditWebsiteView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EditWebsiteView.swift; path = WebsmithApp/Views/EditWebsiteView.swift; sourceTree = "<group>"; };
+		4A5521C629DF0F1F9D84E634 /* HomeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeView.swift; path = WebsmithApp/Views/HomeView.swift; sourceTree = "<group>"; };
+		517206C30C549BBD3725DA7C /* Websmith.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Websmith.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6124A3FAEB9A4F2E84CE2B2F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = WebsmithApp/Info.plist; sourceTree = "<group>"; };
+		659E29552A2B1A1B08C85330 /* WebViewContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebViewContainer.swift; path = WebsmithApp/Views/WebViewContainer.swift; sourceTree = "<group>"; };
+		672AE55F1EFB00699285017B /* OrientationManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrientationManager.swift; path = WebsmithApp/Models/OrientationManager.swift; sourceTree = "<group>"; };
+		6EB8C5CD97ED357D0B4AAF53 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		8E1ADA6E1D7D38B4349CA38D /* WebBrowserView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebBrowserView.swift; path = WebsmithApp/Views/WebBrowserView.swift; sourceTree = "<group>"; };
+		8E4E244F17F4955A07698C5C /* ConfigurationStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConfigurationStore.swift; path = WebsmithApp/Models/ConfigurationStore.swift; sourceTree = "<group>"; };
+		C023EC2EB9BCF390AF45CDAE /* WebsiteConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebsiteConfiguration.swift; path = WebsmithApp/Models/WebsiteConfiguration.swift; sourceTree = "<group>"; };
+		FF9F978D1EC48D381ED2CAD6 /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = WebsmithApp/AppDelegate.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3BC717825BC674D476FB367D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				55521E67FB9D99D28BBCF691 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3EC87C52E2B21B968D892CB0 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				6EB8C5CD97ED357D0B4AAF53 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		A2963F887AE9F947C674645E /* WebsmithApp */ = {
+			isa = PBXGroup;
+			children = (
+				FF9F978D1EC48D381ED2CAD6 /* AppDelegate.swift */,
+				8E4E244F17F4955A07698C5C /* ConfigurationStore.swift */,
+				672AE55F1EFB00699285017B /* OrientationManager.swift */,
+				C023EC2EB9BCF390AF45CDAE /* WebsiteConfiguration.swift */,
+				404EB8F536823F8D56B14159 /* EditWebsiteView.swift */,
+				4A5521C629DF0F1F9D84E634 /* HomeView.swift */,
+				8E1ADA6E1D7D38B4349CA38D /* WebBrowserView.swift */,
+				659E29552A2B1A1B08C85330 /* WebViewContainer.swift */,
+				11A411F19803F8D8AF7D2BCD /* WebsmithApp.swift */,
+				6124A3FAEB9A4F2E84CE2B2F /* Info.plist */,
+			);
+			name = WebsmithApp;
+			sourceTree = "<group>";
+		};
+		CD276F534338B081DC78672E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3EC87C52E2B21B968D892CB0 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E6BBAEB8446944116A47CF25 = {
+			isa = PBXGroup;
+			children = (
+				E81BDAF3C7926A09A9263EEC /* Products */,
+				CD276F534338B081DC78672E /* Frameworks */,
+				A2963F887AE9F947C674645E /* WebsmithApp */,
+			);
+			sourceTree = "<group>";
+		};
+		E81BDAF3C7926A09A9263EEC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				517206C30C549BBD3725DA7C /* Websmith.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		DC91573ACFDB38383334F589 /* Websmith */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB9844A34D73CF8616B93873 /* Build configuration list for PBXNativeTarget "Websmith" */;
+			buildPhases = (
+				2BCCF6121F2406921D4E1617 /* Sources */,
+				3BC717825BC674D476FB367D /* Frameworks */,
+				C033767EA1E7009C3C8C0754 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Websmith;
+			productName = Websmith;
+			productReference = 517206C30C549BBD3725DA7C /* Websmith.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C6DF0DE26DCECAEBA37ACFC7 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+			};
+			buildConfigurationList = 371D30430BB5B4E0053F5806 /* Build configuration list for PBXProject "Websmith" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E6BBAEB8446944116A47CF25;
+			minimizedProjectReferenceProxies = 0;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = E81BDAF3C7926A09A9263EEC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				DC91573ACFDB38383334F589 /* Websmith */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C033767EA1E7009C3C8C0754 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2BCCF6121F2406921D4E1617 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		127D266F3C5EED2B12BDBBD8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				INFOPLIST_FILE = WebsmithApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		16E9D1FA8753939C78B7267A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		5A6135119B09FA43D09A6A9C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				INFOPLIST_FILE = WebsmithApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D49C23EC5F749D3D9F74E0C2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		371D30430BB5B4E0053F5806 /* Build configuration list for PBXProject "Websmith" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D49C23EC5F749D3D9F74E0C2 /* Debug */,
+				16E9D1FA8753939C78B7267A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB9844A34D73CF8616B93873 /* Build configuration list for PBXNativeTarget "Websmith" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				127D266F3C5EED2B12BDBBD8 /* Release */,
+				5A6135119B09FA43D09A6A9C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C6DF0DE26DCECAEBA37ACFC7 /* Project object */;
+}

--- a/WebsmithApp/AppDelegate.swift
+++ b/WebsmithApp/AppDelegate.swift
@@ -1,6 +1,9 @@
 import UIKit
 
-@UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
+
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        OrientationManager.shared.currentMask
+    }
 }

--- a/WebsmithApp/Info.plist
+++ b/WebsmithApp/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Websmith</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.Websmith</string>
+    <key>UILaunchStoryboardName</key>
+    <string></string>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/WebsmithApp/Models/ConfigurationStore.swift
+++ b/WebsmithApp/Models/ConfigurationStore.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SwiftUI
+
+final class ConfigurationStore: ObservableObject {
+    @Published var websites: [WebsiteConfiguration] = []
+
+    func add(_ config: WebsiteConfiguration) {
+        websites.append(config)
+    }
+
+    func remove(_ config: WebsiteConfiguration) {
+        websites.removeAll { $0.id == config.id }
+    }
+
+    func exportConfiguration(_ config: WebsiteConfiguration) throws -> Data {
+        try config.exportJSON()
+    }
+
+    func importConfiguration(from data: Data) throws {
+        let config = try WebsiteConfiguration.importJSON(data)
+        add(config)
+    }
+}

--- a/WebsmithApp/Models/OrientationManager.swift
+++ b/WebsmithApp/Models/OrientationManager.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+final class OrientationManager {
+    static let shared = OrientationManager()
+    private init() {}
+
+    var currentMask: UIInterfaceOrientationMask = .all
+}

--- a/WebsmithApp/Models/WebsiteConfiguration.swift
+++ b/WebsmithApp/Models/WebsiteConfiguration.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum OrientationOption: String, Codable, CaseIterable {
+    case system
+    case portrait
+    case landscape
+}
+
+struct WebsiteConfiguration: Identifiable, Codable, Equatable {
+    var id = UUID()
+    var url: String
+    var nickname: String
+    var allowFullscreen: Bool = false
+    var disableTextSelection: Bool = false
+    var forceOrientation: OrientationOption = .system
+    var showTopBar: Bool = true
+    var customStylesheets: [URL] = []
+    var userScripts: [URL] = []
+    var requestWhitelist: [String] = []
+    var adblockLists: [URL] = []
+
+    func exportJSON() throws -> Data {
+        try JSONEncoder().encode(self)
+    }
+
+    static func importJSON(_ data: Data) throws -> WebsiteConfiguration {
+        try JSONDecoder().decode(WebsiteConfiguration.self, from: data)
+    }
+}

--- a/WebsmithApp/Views/EditWebsiteView.swift
+++ b/WebsmithApp/Views/EditWebsiteView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct EditWebsiteView: View {
+    @EnvironmentObject var store: ConfigurationStore
+    @State private var config = WebsiteConfiguration(url: "", nickname: "")
+    @State private var showImport = false
+    @State private var showShare = false
+
+    var body: some View {
+        Form {
+            Section(header: Text("General")) {
+                TextField("URL", text: $config.url)
+                TextField("Nickname", text: $config.nickname)
+            }
+
+            Section(header: Text("Settings")) {
+                Toggle("Fullscreen", isOn: $config.allowFullscreen)
+                Toggle("Disable Text Selection", isOn: $config.disableTextSelection)
+                Toggle("Show Leave Bar", isOn: $config.showTopBar)
+                Picker("Orientation", selection: $config.forceOrientation) {
+                    ForEach(OrientationOption.allCases, id: \.self) { option in
+                        Text(option.rawValue.capitalized).tag(option)
+                    }
+                }
+            }
+
+            Section(header: Text("Styles & Scripts")) {
+                Text("Custom Stylesheets: \(config.customStylesheets.count)")
+                Text("User Scripts: \(config.userScripts.count)")
+            }
+
+            Section(header: Text("Request Filtering")) {
+                Text("Whitelist entries: \(config.requestWhitelist.count)")
+                Text("Adblock lists: \(config.adblockLists.count)")
+            }
+        }
+        .navigationTitle("Edit Site")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button("Save") { store.add(config) }
+            }
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button("Share") { showShare = true }
+                Button("Import") { showImport = true }
+            }
+        }
+    }
+}

--- a/WebsmithApp/Views/HomeView.swift
+++ b/WebsmithApp/Views/HomeView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject var store: ConfigurationStore
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(store.websites) { site in
+                    NavigationLink(destination: WebBrowserView(configuration: site)) {
+                        HStack {
+                            Image(systemName: "globe")
+                            Text(site.nickname)
+                        }
+                    }
+                }
+                .onDelete { indexSet in
+                    indexSet.map { store.websites[$0] }.forEach { store.remove($0) }
+                }
+            }
+            .navigationTitle("Websmith")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    NavigationLink(destination: EditWebsiteView()) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/WebsmithApp/Views/WebBrowserView.swift
+++ b/WebsmithApp/Views/WebBrowserView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct WebBrowserView: View {
+    @Environment(\.dismiss) private var dismiss
+    let configuration: WebsiteConfiguration
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if configuration.showTopBar {
+                HStack {
+                    Button("Close") { dismiss() }
+                    Spacer()
+                    Text(configuration.nickname)
+                    Spacer()
+                }
+                .padding()
+                .background(Color(UIColor.systemGray6))
+            }
+            WebViewContainer(configuration: configuration)
+                .edgesIgnoringSafeArea(configuration.allowFullscreen ? .all : [])
+        }
+        .onAppear { applyOrientation() }
+        .onDisappear { OrientationManager.shared.currentMask = .all }
+    }
+
+    private func applyOrientation() {
+        switch configuration.forceOrientation {
+        case .portrait:
+            OrientationManager.shared.currentMask = .portrait
+        case .landscape:
+            OrientationManager.shared.currentMask = .landscape
+        case .system:
+            OrientationManager.shared.currentMask = .all
+        }
+    }
+}

--- a/WebsmithApp/Views/WebViewContainer.swift
+++ b/WebsmithApp/Views/WebViewContainer.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import WebKit
+
+struct WebViewContainer: UIViewRepresentable {
+    let configuration: WebsiteConfiguration
+
+    func makeCoordinator() -> Coordinator { Coordinator(configuration: configuration) }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        applyCustomizations(to: webView)
+        if let url = URL(string: configuration.url) {
+            webView.load(URLRequest(url: url))
+        }
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    private func applyCustomizations(to webView: WKWebView) {
+        var js = ""
+        if configuration.disableTextSelection {
+            js += "document.documentElement.style.webkitUserSelect='none';"
+        }
+        for style in configuration.customStylesheets {
+            if let css = try? String(contentsOf: style).replacingOccurrences(of: "\n", with: " ") {
+                js += "var style=document.createElement('style');style.innerHTML=`\(css)`;document.head.appendChild(style);"
+            }
+        }
+        for script in configuration.userScripts {
+            if let content = try? String(contentsOf: script) {
+                js += content
+            }
+        }
+        if !js.isEmpty {
+            let userScript = WKUserScript(source: js, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+            webView.configuration.userContentController.addUserScript(userScript)
+        }
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        let configuration: WebsiteConfiguration
+        init(configuration: WebsiteConfiguration) {
+            self.configuration = configuration
+        }
+
+        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            if let url = navigationAction.request.url?.absoluteString {
+                if !configuration.requestWhitelist.isEmpty && configuration.requestWhitelist.first(where: { url.contains($0) }) == nil {
+                    decisionHandler(.cancel)
+                    return
+                }
+            }
+            decisionHandler(.allow)
+        }
+    }
+}

--- a/WebsmithApp/WebsmithApp.swift
+++ b/WebsmithApp/WebsmithApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct WebsmithApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @StateObject private var store = ConfigurationStore()
+
+    var body: some Scene {
+        WindowGroup {
+            HomeView()
+                .environmentObject(store)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Scaffold SwiftUI-based iOS app that lists configurable websites
- Implement models and views for per-site options like fullscreen, orientation, styles, scripts, and request filtering
- Add GitHub Actions workflow to build the project into an IPA artifact

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68a264bd9294832b96f88ca7a9175656