### PR TITLE
Add website customization options and iOS build workflow

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,9 +1,7 @@
 name: iOS Build
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,21 +1,21 @@
 name: iOS Build
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
 
 jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Build
+      - uses: actions/checkout@v3
+      - name: Build IPA
         run: |
-          xcodebuild -project Websmith.xcodeproj -scheme Websmith -configuration Release -sdk iphoneos -archivePath build/Websmith.xcarchive CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO archive
-          mkdir -p build/Payload
-          cp -R build/Websmith.xcarchive/Products/Applications/Websmith.app build/Payload/
-          cd build && zip -r Websmith.ipa Payload
-      - name: Upload IPA
-        uses: actions/upload-artifact@v4
+          xcodebuild -project Websmith.xcodeproj -scheme WebsmithApp -sdk iphoneos -configuration Release -archivePath build/Websmith.xcarchive archive
+          xcodebuild -exportArchive -archivePath build/Websmith.xcarchive -exportPath build -exportOptionsPlist ExportOptions.plist
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
         with:
-          name: Websmith
-          path: build/Websmith.ipa
+          name: WebsmithApp.ipa
+          path: build/*.ipa

--- a/WebsmithApp/Models/WebsiteConfiguration.swift
+++ b/WebsmithApp/Models/WebsiteConfiguration.swift
@@ -14,6 +14,8 @@ struct WebsiteConfiguration: Identifiable, Codable, Equatable {
     var disableTextSelection: Bool = false
     var forceOrientation: OrientationOption = .system
     var showTopBar: Bool = true
+    var allowCookies: Bool = true
+    var allowBackForwardGestures: Bool = true
     var customStylesheets: [URL] = []
     var userScripts: [URL] = []
     var requestWhitelist: [String] = []

--- a/WebsmithApp/Views/EditWebsiteView.swift
+++ b/WebsmithApp/Views/EditWebsiteView.swift
@@ -1,10 +1,21 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct EditWebsiteView: View {
     @EnvironmentObject var store: ConfigurationStore
-    @State private var config = WebsiteConfiguration(url: "", nickname: "")
+    @State private var config: WebsiteConfiguration
     @State private var showImport = false
     @State private var showShare = false
+    @State private var showDeleteConfirm = false
+    @State private var showLeaveWarning = false
+    @State private var showStyleImporter = false
+    @State private var showScriptImporter = false
+    @State private var showAdblockImporter = false
+    @State private var newWhitelistEntry = ""
+
+    init(configuration: WebsiteConfiguration? = nil) {
+        _config = State(initialValue: configuration ?? WebsiteConfiguration(url: "", nickname: ""))
+    }
 
     var body: some View {
         Form {
@@ -16,7 +27,12 @@ struct EditWebsiteView: View {
             Section(header: Text("Settings")) {
                 Toggle("Fullscreen", isOn: $config.allowFullscreen)
                 Toggle("Disable Text Selection", isOn: $config.disableTextSelection)
+                Toggle("Allow Cookies", isOn: $config.allowCookies)
+                Toggle("Allow Gestures", isOn: $config.allowBackForwardGestures)
                 Toggle("Show Leave Bar", isOn: $config.showTopBar)
+                    .onChange(of: config.showTopBar) { value in
+                        if !value { showLeaveWarning = true }
+                    }
                 Picker("Orientation", selection: $config.forceOrientation) {
                     ForEach(OrientationOption.allCases, id: \.self) { option in
                         Text(option.rawValue.capitalized).tag(option)
@@ -24,14 +40,43 @@ struct EditWebsiteView: View {
                 }
             }
 
-            Section(header: Text("Styles & Scripts")) {
-                Text("Custom Stylesheets: \(config.customStylesheets.count)")
-                Text("User Scripts: \(config.userScripts.count)")
+            Section(header: Text("Custom Stylesheets")) {
+                ForEach(config.customStylesheets, id: \.self) { url in
+                    Text(url.lastPathComponent)
+                }
+                .onDelete { config.customStylesheets.remove(atOffsets: $0) }
+                Button("Add Stylesheet") { showStyleImporter = true }
             }
 
-            Section(header: Text("Request Filtering")) {
-                Text("Whitelist entries: \(config.requestWhitelist.count)")
-                Text("Adblock lists: \(config.adblockLists.count)")
+            Section(header: Text("User Scripts")) {
+                ForEach(config.userScripts, id: \.self) { url in
+                    Text(url.lastPathComponent)
+                }
+                .onDelete { config.userScripts.remove(atOffsets: $0) }
+                Button("Add Script") { showScriptImporter = true }
+            }
+
+            Section(header: Text("Request Whitelist")) {
+                ForEach(config.requestWhitelist, id: \.self) { entry in
+                    Text(entry)
+                }
+                .onDelete { config.requestWhitelist.remove(atOffsets: $0) }
+                HStack {
+                    TextField("Add entry", text: $newWhitelistEntry)
+                    Button("Add") {
+                        guard !newWhitelistEntry.isEmpty else { return }
+                        config.requestWhitelist.append(newWhitelistEntry)
+                        newWhitelistEntry = ""
+                    }
+                }
+            }
+
+            Section(header: Text("Adblock Lists")) {
+                ForEach(config.adblockLists, id: \.self) { url in
+                    Text(url.lastPathComponent)
+                }
+                .onDelete { config.adblockLists.remove(atOffsets: $0) }
+                Button("Import List") { showAdblockImporter = true }
             }
         }
         .navigationTitle("Edit Site")
@@ -42,6 +87,48 @@ struct EditWebsiteView: View {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 Button("Share") { showShare = true }
                 Button("Import") { showImport = true }
+                Button("Delete", role: .destructive) { showDeleteConfirm = true }
+            }
+        }
+        .alert("Removing the leave bar will require restarting the app to exit.", isPresented: $showLeaveWarning) {
+            Button("OK", role: .cancel) {}
+        }
+        .alert("Delete this site?", isPresented: $showDeleteConfirm) {
+            Button("Delete", role: .destructive) {
+                store.remove(config)
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .sheet(isPresented: $showShare) {
+            if let data = try? config.exportJSON() {
+                ShareSheet(data: data, fileName: "\(config.nickname).json")
+            } else {
+                Text("Unable to export")
+            }
+        }
+        .fileImporter(isPresented: $showImport, allowedContentTypes: [.json]) { result in
+            switch result {
+            case .success(let url):
+                if let data = try? Data(contentsOf: url), let imported = try? WebsiteConfiguration.importJSON(data) {
+                    config = imported
+                }
+            case .failure:
+                break
+            }
+        }
+        .fileImporter(isPresented: $showStyleImporter, allowedContentTypes: [.css]) { result in
+            if case .success(let url) = result {
+                config.customStylesheets.append(url)
+            }
+        }
+        .fileImporter(isPresented: $showScriptImporter, allowedContentTypes: [.javascript]) { result in
+            if case .success(let url) = result {
+                config.userScripts.append(url)
+            }
+        }
+        .fileImporter(isPresented: $showAdblockImporter, allowedContentTypes: [.plainText]) { result in
+            if case .success(let url) = result {
+                config.adblockLists.append(url)
             }
         }
     }

--- a/WebsmithApp/Views/HomeView.swift
+++ b/WebsmithApp/Views/HomeView.swift
@@ -7,10 +7,16 @@ struct HomeView: View {
         NavigationView {
             List {
                 ForEach(store.websites) { site in
-                    NavigationLink(destination: WebBrowserView(configuration: site)) {
-                        HStack {
-                            Image(systemName: "globe")
-                            Text(site.nickname)
+                    HStack {
+                        NavigationLink(destination: WebBrowserView(configuration: site)) {
+                            HStack {
+                                Image(systemName: "globe")
+                                Text(site.nickname)
+                            }
+                        }
+                        Spacer()
+                        NavigationLink(destination: EditWebsiteView(configuration: site)) {
+                            Image(systemName: "gearshape")
                         }
                     }
                 }
@@ -23,6 +29,11 @@ struct HomeView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     NavigationLink(destination: EditWebsiteView()) {
                         Image(systemName: "plus")
+                    }
+                }
+                ToolbarItem(placement: .navigationBarLeading) {
+                    NavigationLink(destination: SettingsView()) {
+                        Image(systemName: "gear")
                     }
                 }
             }

--- a/WebsmithApp/Views/SettingsView.swift
+++ b/WebsmithApp/Views/SettingsView.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Form {
+            Text("App Settings")
+        }
+        .navigationTitle("Settings")
+    }
+}

--- a/WebsmithApp/Views/ShareSheet.swift
+++ b/WebsmithApp/Views/ShareSheet.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let data: Data
+    let fileName: String
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        try? data.write(to: tempURL)
+        return UIActivityViewController(activityItems: [tempURL], applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}


### PR DESCRIPTION
## Summary
- enable per-site controls for cookies, navigation gestures, styles, scripts, whitelists, and adblock lists
- allow exporting/importing website configs with share sheet and document picker
- add GitHub Action to build iOS IPA artifact

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc WebsmithApp/Views/HomeView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68a26d3aa9c4832b9974cb20dc49e0a0